### PR TITLE
Fix #22 - дубликаты SKU в merge_analysis_result

### DIFF
--- a/projects/abc_xyz/get_product_abc_xyz_analysis.py
+++ b/projects/abc_xyz/get_product_abc_xyz_analysis.py
@@ -95,6 +95,8 @@ def get_xyz_analysis(products):
 
 def merge_analysis_result(margin_table, stability_table, sku_list):
     '''Объединяет результаты ABC- и XYZ-анализа в одну таблицу'''
+    if margin_table['SKU'].duplicated().any():
+        raise ValueError('duplicate SKU in margin table')
     result_matrix = pd.DataFrame()
     result_matrix['SKU'] = sku_list
     result_matrix['Margin'] = [list(margin_table[margin_table['SKU'] == sku]['Margin'])[0] for sku in sku_list]


### PR DESCRIPTION
Суть фикса: не дедупликация и не агрегация по SKU, а явная ошибка, если в margin_table уже есть дубликаты по SKU. То есть устраняется именно часть «молча» — итог больше не может выглядеть осмысленным при повторах, вместо этого расчёт падает с ValueError и текстом про duplicate.