### PR TITLE
Fix for TestPriority2Issues::test_prepare_products_raises_on_invalid_day

### DIFF
--- a/projects/abc_xyz/get_product_abc_xyz_analysis.py
+++ b/projects/abc_xyz/get_product_abc_xyz_analysis.py
@@ -26,7 +26,9 @@ def prepare_products(filename):
     data = pd.read_csv(filename)
     # Удаляем служебные колонки индекса, если CSV был сохранен с index=True
     data = data.loc[:, ~data.columns.str.startswith('Unnamed')]
-    data['Day'] = pd.to_datetime(data['Day'])
+    data['Day'] = pd.to_datetime(data['Day'], errors='coerce')
+    if data['Day'].isna().any():
+        raise ValueError('Invalid or missing Day')
 
     sku_list = list(data['SKU'].unique())
     prepared_products = []


### PR DESCRIPTION
Исправление такое: не полагаться на «сырой» ValueError от pandas, а самим парсить даты с errors='coerce' и при любых NaT бросать ValueError('Invalid or missing Day').

Почему так: при errors='coerce' строка вроде "not-a-date" становится NaT, без длинного текста от pandas. Проверка isna().any() ловит и битые строки, и пустые значения, если они превратились в NaT.